### PR TITLE
LXC refactor fixes

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -1606,7 +1606,7 @@ def clone(name,
         cmd += ' -B {0}'.format(backing)
         if backing not in ('dir', 'overlayfs'):
             if size:
-                cmd += ' --fssize {0}'.format(size)
+                cmd += ' -L {0}'.format(size)
 
     ret = __salt__['cmd.run_all'](cmd)
     _clear_context()

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -201,7 +201,7 @@ def cloud_init_interface(name, vm_=None, **kwargs):
         vm_ = {}
     vm_ = copy.deepcopy(vm_)
     vm_ = salt.utils.dictupdate.update(vm_, kwargs)
-    profile = _lxc_profile(vm_.get('profile', {}))
+    profile = get_container_profile(vm_.get('profile', {}))
     if name is None:
         name = vm_['name']
     from_container = vm_.get('from_container', None)

--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -261,7 +261,7 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
                 expr_form='list', timeout=600).get(host, {})
         name = kw.pop('name', name)
         # be sure not to seed an already seeded host
-        kw['seed'] = seeds[name]
+        kw['seed'] = seeds.get(name, True)
         if not kw['seed']:
             kw.pop('seed_cmd', '')
         cmds.append(


### PR DESCRIPTION
As requested in saltstack/salt issue #14865, I have been testing the lxc-refactor branch.

Here are a few fixes I had to apply to have a successful run of `salt-call state.sls cloud`.

There are two more points that are not in this PR but need to be discussed as I have no idea how to do it right now.
1. On my distribution (Gentoo), lxc configuration is located in `/etc/lxc`. This is fine since there is effectively only configuration files there for me but this is not configurable in Salt. How would I go about fixing that ? For now, I am just fixing it locally using sed.
2. lxc-clone is blocking salt-call with a silly question. It detects a filesystem signature on the LV after I created the silly folder for it to mount the one to clone from (which is based on LV name, not rootfs...) and asks if I want to wipe it. I haven't found a documented option to force it to proceed. It seems like echoing to fd 0 of the process made it continue but this is not ideal.

Here is the output of lxc-clone for reference:

```
# lxc-clone --help
Usage: lxc-clone [-s] [-B backingstore] [-L size[unit]] [-K] [-M] [-H]
          [-p lxcpath] [-P newlxcpath] orig new

  -s: snapshot rather than copy
  -B: use specified new backingstore.  Default is the same as
      the original.  Options include aufs, btrfs, lvm, overlayfs,
      dir and loop
  -L: for blockdev-backed backingstore, use specified size * specified
      unit. Default size is the size of the source blockdev, default
      unit is MB
  -K: Keep name - do not change the container name
  -M: Keep macaddr - do not choose a random new mac address
  -p: use container orig from custom lxcpath
  -P: create container new in custom lxcpath
```

I have only tested with a clone for now so there might be more issues than that.
